### PR TITLE
ClassNotFound errors

### DIFF
--- a/src/langohr/basic.clj
+++ b/src/langohr/basic.clj
@@ -102,7 +102,7 @@
 
 
 
-(defn consume
+(defn ^String consume
   "Adds new consumer to a queue using basic.consume AMQP method.
 
    Called with default parameters, starts non-nolocal, non-exclusive consumer with explicit acknowledgement and server-generated consumer tag.
@@ -118,9 +118,9 @@
      ^Boolean :no-local (default false) - flag set to true unless server local buffering is required.
 
 "
-  (^String [^Channel channel, ^String queue, ^Consumer consumer, &{ :keys [consumer-tag auto-ack exclusive arguments no-local]
-                                                                   :or { consumer-tag "", auto-ack false, exclusive false, no-local false } }]
-           (.basicConsume ^Channel channel ^String queue ^Boolean auto-ack ^String consumer-tag ^Boolean no-local ^Boolean exclusive ^Map arguments ^Consumer consumer)))
+  [^Channel channel, ^String queue, ^Consumer consumer, &{ :keys [consumer-tag auto-ack exclusive arguments no-local]
+                                                          :or { consumer-tag "", auto-ack false, exclusive false, no-local false } }]
+  (.basicConsume ^Channel channel ^String queue ^Boolean auto-ack ^String consumer-tag ^Boolean no-local ^Boolean exclusive ^Map arguments ^Consumer consumer))
 
 
 (defn cancel
@@ -129,12 +129,12 @@
   (.basicCancel ^Channel channel ^String consumer-tag))
 
 
-(defn get
+(defn ^GetResponse get
   "Fetches a message from a queue using basic.get AMQP method"
-  (^GetResponse [^Channel channel, ^String queue]
-                (.basicGet channel queue true))
-  (^GetResponse [^Channel channel, ^String queue, ^Boolean auto-ack]
-                (.basicGet channel queue auto-ack)))
+  ([^Channel channel, ^String queue]
+     (.basicGet channel queue true))
+  ([^Channel channel, ^String queue, ^Boolean auto-ack]
+     (.basicGet channel queue auto-ack)))
 
 
 

--- a/src/langohr/channel.clj
+++ b/src/langohr/channel.clj
@@ -15,10 +15,10 @@
 ;; API
 ;;
 
-(defn open
+(defn ^Channel open
   "Opens a new channel on given connection using channel.open AMQP method"
-  (^Channel [^Connection connection]
-            (.createChannel connection)))
+  [^Connection connection]
+  (.createChannel connection))
 
 
 (defn close
@@ -35,13 +35,13 @@
   (.isOpen channel))
 
 
-(defn flow?
+(defn ^Boolean flow?
   "Returns true if flow is active on given channel. Uses channel.flow AMQP method."
-  (^Boolean [^Channel channel]
-            (.getActive (.getFlow channel))))
+  ([^Channel channel]
+     (.getActive (.getFlow channel))))
 
 
-(defn flow
+(defn ^AMQP$Channel$FlowOk flow
   "Enables or disables channel flow using channel.flow AMQP method"
-  (^AMQP$Channel$FlowOk [^Channel channel ^Boolean on]
-                        (.flow channel on)))
+  ([^Channel channel ^Boolean on]
+     (.flow channel on)))

--- a/src/langohr/consumers.clj
+++ b/src/langohr/consumers.clj
@@ -19,9 +19,9 @@
 ;; API
 ;;
 
-(defn create-default
+(defn ^Consumer create-default
   "Instantiates and returns a new consumer that handles various consumer life cycle events. See also langohr.basic/consume."
-  ^Consumer [^Channel channel &{ :keys [consume-ok-fn cancel-fn cancel-ok-fn shutdown-signal-fn recover-ok-fn handle-delivery-fn] }]
+  [^Channel channel &{ :keys [consume-ok-fn cancel-fn cancel-ok-fn shutdown-signal-fn recover-ok-fn handle-delivery-fn] }]
   (proxy [DefaultConsumer] [^Channel channel]
     (handleConsumeOk [^String consumer-tag]
       (when consume-ok-fn

--- a/src/langohr/core.clj
+++ b/src/langohr/core.clj
@@ -55,21 +55,21 @@
 ;;
 
 (declare create-connection-factory)
-(defn connect
+(defn ^Connection connect
   "Creates and returns a new connection to RabbitMQ."
   ;; defaults
-  (^Connection []
-               (let [conn-factory (ConnectionFactory.)]
-                 (.newConnection conn-factory)))
+  ([]
+     (let [conn-factory (ConnectionFactory.)]
+       (.newConnection conn-factory)))
   ;; settings
-  (^Connection [settings]
-               (let [^ConnectionFactory conn-factory (create-connection-factory settings)]
-                 (.newConnection conn-factory))))
+  ([settings]
+     (let [^ConnectionFactory conn-factory (create-connection-factory settings)]
+       (.newConnection conn-factory))))
 
 
-(defn create-channel
+(defn ^Channel create-channel
   "Delegates to langohr.channel/open, kept for backwards compatibility"
-  ^Channel [& args]
+  [& args]
   (apply langohr.channel/open args))
 
 
@@ -102,9 +102,9 @@
   (merge (env-config (:uri config (System/getenv "RABBITMQ_URL")))
          config))
 
-(defn- create-connection-factory
+(defn- ^ConnectionFactory create-connection-factory
   "Creates connection factory from given attributes"
-  ^ConnectionFactory [config]
+  [config]
   (let [{:keys [host port username password vhost]} (get-config config)]
     (doto (ConnectionFactory.)
       (.setUsername    username)

--- a/src/langohr/exchange.clj
+++ b/src/langohr/exchange.clj
@@ -16,7 +16,7 @@
 ;; API
 ;;
 
-(defn declare
+(defn ^AMQP$Exchange$DeclareOk declare
   "Declares an exchange using exchange.declare AMQP method.
 
    By default declares non-autodeleted non-durable exchanges.
@@ -35,13 +35,13 @@
      :auto-delete (default: false): If set when creating a new exchange, the exchange will be marked as durable. Durable exchanges remain active when a server restarts. Non-durable exchanges (transient exchanges) are purged if/when a server restarts.
      :durable (default: false): indicates wether the exchange is durable. Information about Durable Exchanges is persisted and restored after server restart. Non-durable (transient) exchanges do not survive the server restart.
      :internal (default: false): If set, the exchange may not be used directly by publishers, but only when bound to other exchanges. Internal exchanges are used to construct wiring that is not visible to applications."
-  (^AMQP$Exchange$DeclareOk [^Channel channel ^String name ^String type]
+  ([^Channel channel ^String name ^String type]
      (.exchangeDeclare channel name type))
-  (^AMQP$Exchange$DeclareOk [^Channel channel ^String name ^String type &{ :keys [durable auto-delete internal arguments] :or {durable false, auto-delete false, internal false} }]
+  ([^Channel channel ^String name ^String type &{ :keys [durable auto-delete internal arguments] :or {durable false, auto-delete false, internal false} }]
      (.exchangeDeclare channel name type durable auto-delete internal arguments)))
 
 
-(defn delete
+(defn ^AMQP$Exchange$DeleteOk delete
   "Deletes an exchange using exchange.delete AMQP method. When an exchange is deleted all queue bindings on the exchange are cancelled.
 
   Options:
@@ -52,19 +52,19 @@
      (lhe/delete channel exchange true)
 
   "
-  (^AMQP$Exchange$DeleteOk [^Channel channel ^String name]
+  ([^Channel channel ^String name]
      (.exchangeDelete channel name))
-  (^AMQP$Exchange$DeleteOk [^Channel channel ^String name if-unused]
+  ([^Channel channel ^String name if-unused]
      (.exchangeDelete channel name if-unused)))
 
 
-(defn bind
+(defn ^AMQP$Exchange$BindOk bind
   "Binds a queue to an exchange using exchange.bind AMQP method (a RabbitMQ-specific extension)
 
   Options:
     :routing-key (default: \"\"): Specifies the routing key for the binding. The routing key is used for routing messages depending on the exchange configuration. Not all exchanges use a routing key - refer to the specific exchange documentation.
     :arguments (default: nil): A hash of optional arguments with the declaration. Headers exchange type uses these metadata attributes for routing matching. In addition, brokers may implement AMQP extensions using x-prefixed declaration arguments."
-  (^AMQP$Exchange$BindOk [^Channel channel ^String destination ^String source]
+  ([^Channel channel ^String destination ^String source]
      (.exchangeBind channel destination source ""))
-  (^AMQP$Exchange$BindOk [^Channel channel ^String destination ^String source &{ :keys [routing-key arguments] :or { routing-key "", arguments nil } }]
+  ([^Channel channel ^String destination ^String source &{ :keys [routing-key arguments] :or { routing-key "", arguments nil } }]
      (.exchangeBind channel destination source routing-key arguments)))

--- a/src/langohr/queue.clj
+++ b/src/langohr/queue.clj
@@ -16,13 +16,13 @@
 ;; API
 ;;
 
-(defn declare
+(defn ^AMQP$Queue$DeclareOk declare
   "Declares a queue using queue.declare AMQP method"
-  (^AMQP$Queue$DeclareOk [^Channel channel]
+  ([^Channel channel]
      (.queueDeclare channel))
-  (^AMQP$Queue$DeclareOk [^Channel channel ^String queue]
+  ([^Channel channel ^String queue]
      (.queueDeclare channel queue false true true nil))
-  (^AMQP$Queue$DeclareOk [^Channel channel ^String queue &{:keys [durable exclusive auto-delete arguments] :or {durable false, exclusive true, auto-delete true}}]
+  ([^Channel channel ^String queue &{:keys [durable exclusive auto-delete arguments] :or {durable false, exclusive true, auto-delete true}}]
      (.queueDeclare channel queue durable exclusive auto-delete arguments)))
 
 
@@ -32,33 +32,33 @@
   (.queueDeclarePassive channel queue))
 
 
-(defn bind
+(defn ^AMQP$Queue$BindOk bind
   "Binds a queue to an exchange using queue.bind AMQP method"
-  (^AMQP$Queue$BindOk [^Channel channel ^String queue ^String exchange]
+  ([^Channel channel ^String queue ^String exchange]
      (.queueBind channel queue exchange ""))
-  (^AMQP$Queue$BindOk [^Channel channel ^String queue ^String exchange &{ :keys [routing-key arguments] :or { routing-key "", arguments nil } }]
+  ([^Channel channel ^String queue ^String exchange &{ :keys [routing-key arguments] :or { routing-key "", arguments nil } }]
      (.queueBind channel queue exchange routing-key arguments)))
 
 
-(defn unbind
+(defn ^AMQP$Queue$UnbindOk unbind
   "Unbinds a queue from an exchange using queue.bind AMQP method"
-  (^AMQP$Queue$UnbindOk [^Channel channel ^String queue ^String exchange ^String routing-key]
+  ([^Channel channel ^String queue ^String exchange ^String routing-key]
      (.queueUnbind channel queue exchange routing-key))
-  (^AMQP$Queue$UnbindOk[^Channel channel ^String queue ^String exchange ^String routing-key ^Map arguments]
+  ([^Channel channel ^String queue ^String exchange ^String routing-key ^Map arguments]
      (.queueUnbind channel queue exchange routing-key arguments)))
 
 
-(defn delete
+(defn ^AMQP$Queue$DeleteOk delete
   "Deletes a queue using queue.delete AMQP method"
-  (^AMQP$Queue$DeleteOk [^Channel channel ^String queue]
+  ([^Channel channel ^String queue]
      (.queueDelete channel queue))
-  (^AMQP$Queue$DeleteOk[^Channel channel ^String queue if-unused if-empty]
+  ([^Channel channel ^String queue if-unused if-empty]
      (.queueDelete channel queue if-unused if-empty)))
 
 
-(defn purge
+(defn ^AMQP$Queue$PurgeOk purge
   "Purges a queue using queue.purge AMQP method"
-  ^AMQP$Queue$PurgeOk [^Channel channel ^String queue]
+  [^Channel channel ^String queue]
   (.queuePurge channel queue))
 
 


### PR DESCRIPTION
I was getting odd errors about missing classes in places where importing the class shouldn't have been needed.

Moving the type hinting on return values fixes this issue.
