### PR TITLE
Connect to addresses until one succeeds

### DIFF
--- a/src/clojure/langohr/core.clj
+++ b/src/clojure/langohr/core.clj
@@ -71,12 +71,12 @@
               (for [[host port] addresses]
                 (Address. host (or port ConnectionFactory/DEFAULT_AMQP_PORT)))))
 
-(defn ^Connection connect-with-addresses
+(defn ^Connection connect-to-first-available
   "Creates and returns a new connection to RabbitMQ. addresses is a
    sequence of host/port pairs, to try in order until one succeeds."
   ;; defaults
   ([addresses]
-     (connect-with-addresses addresses {}))
+     (connect-to-first-available addresses {}))
   ;; settings
   ([settings addresses]
      (.newConnection ^ConnectionFactory (create-connection-factory settings)

--- a/test/langohr/test/core_test.clj
+++ b/test/langohr/test/core_test.clj
@@ -29,9 +29,9 @@
     (is (= 5672        (.getPort conn)))
     (is (-> conn .getServerProperties (get "capabilities") (get "publisher_confirms")))))
 
-(deftest t-connection-with-addresses
+(deftest t-connection-to-first-available
   ;; see ./bin/ci/before_script.sh
-  (let [conn (connect-with-addresses {
+  (let [conn (connect-to-first-available {
                        :vhost "langohr_testbed" :username "langohr" :password "langohr.password"
                        :requested-heartbeat 3 :connection-timeout 5 }
                [["127.0.0.1" 0]
@@ -41,9 +41,9 @@
     (is (= 5672        (.getPort conn)))
     (is (= 3           (.getHeartbeat conn)))))
 
-(deftest t-connection-with-addresses-without-port
+(deftest t-connection-to-first-available-missing-port
   ;; see ./bin/ci/before_script.sh
-  (let [conn (connect-with-addresses {
+  (let [conn (connect-to-first-available {
                        :vhost "langohr_testbed" :username "langohr" :password "langohr.password"
                        :requested-heartbeat 3 :connection-timeout 5 }
                [["127.0.0.1"]])]


### PR DESCRIPTION
Support for a convenience feature, where you can connect to an array of addresses.
http://www.rabbitmq.com/api-guide.html#advanced-connection

I'm not sure my design so far is reasonable. If we don't want a breaking change, perhaps it's better to have a :backups or :failover option in the connections settings.
