### PR TITLE
Blocking consumers

### DIFF
--- a/src/clojure/langohr/consumers.clj
+++ b/src/clojure/langohr/consumers.clj
@@ -91,8 +91,8 @@
 
 (defn blocking-subscribe
   "Adds new QueueingConsumer to a queue using basic.consume AMQP 0.9.1 method"
-  [^Channel channel ^Queue queue f & options]
+  [^Channel channel ^String queue f & options]
   (let [consumer (QueueingConsumer. channel)]
     (apply lhb/consume channel queue consumer options)
-    (doseq [^Delivery d (consumer-seq consumer)]
+    (doseq [^QueueingConsumer$Delivery d (consumer-seq consumer)]
       (f channel (to-message-metadata d) (.getBody d)))))


### PR DESCRIPTION
Appreciate that you're cool with me pushing to master, but I prefer pull requests.

I think this is the cleanest way to support blocking consumers, but I'm happy to discuss if you think it should be integrated into `subscribe` somehow.
