### PR TITLE
Fix automatic recovery of channels that are created without an explicit number

### DIFF
--- a/src/java/com/novemberain/langohr/Connection.java
+++ b/src/java/com/novemberain/langohr/Connection.java
@@ -231,7 +231,7 @@ public class Connection implements com.rabbitmq.client.Connection, Recoverable {
    * @param delegateChannel A RabbitMQ channel.
    * @return The Langohr channel.
    */
-  private Channel createChannel(com.rabbitmq.client.Channel delegateChannel) {
+  private Channel wrapChannel(com.rabbitmq.client.Channel delegateChannel) {
     final Channel channel = new Channel(this, delegateChannel);
     this.registerChannel(channel);
     return channel;
@@ -245,7 +245,7 @@ public class Connection implements com.rabbitmq.client.Connection, Recoverable {
    * @throws java.io.IOException if an I/O problem is encountered
    */
   public Channel createChannel(int channelNumber) throws IOException {
-    return this.createChannel(delegate.createChannel(channelNumber));
+    return this.wrapChannel(delegate.createChannel(channelNumber));
   }
 
   private void registerChannel(Channel channel) {
@@ -283,7 +283,7 @@ public class Connection implements com.rabbitmq.client.Connection, Recoverable {
    * @throws java.io.IOException if an I/O problem is encountered
    */
   public Channel createChannel() throws IOException {
-    return this.createChannel(delegate.createChannel());
+    return this.wrapChannel(delegate.createChannel());
   }
 
   /**

--- a/test/langohr/test/channel_test.clj
+++ b/test/langohr/test/channel_test.clj
@@ -53,15 +53,3 @@
     (is (lch/flow? ch))
     (lch/close ch)
     (is (not (lch/open? ch)))))
-
-(deftest test-channel-reconnects-automatically
-  (let [conn (lc/connect {:automatically-recover true})
-        ch (lch/open conn)
-        latch (java.util.concurrent.CountDownLatch. 1)]
-    (lc/on-recovery ch (fn [ch']
-                         (.countDown latch)))
-    (is (lch/open? ch))
-    (lc/close conn)
-    (is (not (lch/open? ch)))
-    (is (.await latch 10 java.util.concurrent.TimeUnit/SECONDS))
-    (is (lch/open? ch))))


### PR DESCRIPTION
As discussed [on the mailing list](https://groups.google.com/forum/?fromgroups=#!topic/clojure-rabbitmq/Tzx0g0t6lv4).
