### PR TITLE
use the wrapper class instances of `Connection` and `Channel`

### DIFF
--- a/src/java/com/novemberain/langohr/Channel.java
+++ b/src/java/com/novemberain/langohr/Channel.java
@@ -946,7 +946,7 @@ public class Channel implements com.rabbitmq.client.Channel, Recoverable {
 
   public void runRecoveryHooks() {
     for(IFn f : this.recoveryHooks) {
-      f.invoke(this.delegate);
+      f.invoke(this);
     }
   }
 

--- a/src/java/com/novemberain/langohr/Connection.java
+++ b/src/java/com/novemberain/langohr/Connection.java
@@ -97,7 +97,7 @@ public class Connection implements com.rabbitmq.client.Connection, Recoverable {
     this.recoverChannels();
 
     for (IFn f : recoveryHooks) {
-      f.invoke(this.delegate);
+      f.invoke(this);
     }
     this.runChannelRecoveryHooks();
   }


### PR DESCRIPTION
instead of the raw delegates for recovery callback notifications

Fixes #29
