### PR TITLE
Only recover connection if it was NOT initiated by the application

### DIFF
--- a/src/java/com/novemberain/langohr/Connection.java
+++ b/src/java/com/novemberain/langohr/Connection.java
@@ -71,7 +71,9 @@ public class Connection implements com.rabbitmq.client.Connection, Recoverable {
     automaticRecoveryListener = new ShutdownListener() {
       public void shutdownCompleted(ShutdownSignalException cause) {
         try {
-          c.beginAutomaticRecovery();
+          if(!cause.isInitiatedByApplication()){
+            c.beginAutomaticRecovery();
+          }
         } catch (InterruptedException e) {
           // no-op, we cannot really do anything useful here,
           // doing nothing will prevent automatic recovery


### PR DESCRIPTION
Recovery should only happen if the application itself didn't explicitely
trigger the `close` functionality. Else the recovery mechanism would
prevent a complete disconnect in every case.
