### PR TITLE
Handle non-json responses: Return body as string

### DIFF
--- a/src/clojure/langohr/http.clj
+++ b/src/clojure/langohr/http.clj
@@ -31,6 +31,13 @@
   (str *endpoint* slash (s/join slash segments)))
 
 
+(defn safe-json-decode 
+  "Try to parse json response. If the content-type is not json, just return the body (string)."
+  [{body :body, {content-type "content-type"} :headers}]
+  (if (.contains (.toLowerCase content-type) "json")
+    (json/decode body true)
+    body))
+
 (defn post
   [^String uri &{:keys [body] :as options}]
   (io! (:body (http/post uri (merge options {:accept :json :basic-auth [*username* *password*] :body (json/encode body) :content-type "application/json"}))) true))
@@ -41,9 +48,9 @@
 
 (defn get
   ([^String uri]
-     (io! (json/decode (:body (http/get uri {:accept :json :basic-auth [*username* *password*] :throw-exceptions throw-exceptions :content-type "application/json"})) true)))
+     (io! (safe-json-decode (http/get uri {:accept :json :basic-auth [*username* *password*] :throw-exceptions throw-exceptions :content-type "application/json"}))))
   ([^String uri &{:as options}]
-     (io! (json/decode (:body (http/get uri (merge options {:accept :json :basic-auth [*username* *password*] :throw-exceptions throw-exceptions :content-type "application/json"}))) true))))
+     (io! (safe-json-decode (http/get uri (merge options {:accept :json :basic-auth [*username* *password*] :throw-exceptions throw-exceptions :content-type "application/json"}))))))
 
 (defn head
   [^String uri]

--- a/test/langohr/test/http_api_test.clj
+++ b/test/langohr/test/http_api_test.clj
@@ -71,6 +71,11 @@
     (is (:durable r))
     (is (:arguments r))))
 
+(deftest ^{:http true} test-get-non-existing-vhost
+  (let [response (hc/list-exchanges "amq.non-existing-vhost")]
+    ; since this vhost does not exist, there is no JSON response, just the body as a string
+    (is (string? response))))
+
 (deftest ^{:http true} test-declare-and-delete-exchange
   (let [s  "langohr.http.fanout"
         r1 (hc/declare-exchange "/" s {:durable false :auto_delete true :internal false :arguments {}})


### PR DESCRIPTION
Right now whenever I try to access non existing resources via the http management api the json decoder throws an exception since he tries to parse html as json. I think we should only parse json if the content type suggests so and return the body string otherwise.

What do you think?
