### PR TITLE
[fix] avoid StackOverflow because  with one parameter calls itself

### DIFF
--- a/src/clojure/langohr/http.clj
+++ b/src/clojure/langohr/http.clj
@@ -77,7 +77,7 @@
 
 (defn ^{:private true} delete
   ([^String uri]
-     (delete {}))
+     (delete uri {}))
   ([^String uri {:keys [body] :as options}]
      (io! (:body (http/delete uri (merge *default-http-options* options {:basic-auth [*username* *password*]
                                                                          :body (json/encode body)}))) true)))


### PR DESCRIPTION
This seems to be a simple copy/paste error, I assume. The current code calls the same arity in an endless loop until the JVM throws a StackOverflowError.
