### PR TITLE
configure codox to link to the source code

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,8 @@
              :dev {:dependencies [[org.clojure/tools.cli "0.4.1" :exclusions [org.clojure/clojure]]]
                    :resource-paths ["test/resources"]
                    :plugins [[lein-codox "0.10.3"]]
-                   :codox {:source-paths ["src/clojure"]}}}
+                   :codox {:source-paths ["src/clojure"]
+                           :source-uri "https://github.com/michaelklishin/langohr/blob/v{version}/{filepath}#L{line}"}}}
   :source-paths      ["src/clojure"]
   :java-source-paths ["src/java"]
   :javac-options     ["-target" "1.8" "-source" "1.8"]


### PR DESCRIPTION
👋

I can't seem to find where or how the docs are created that results in the http://reference.clojurerabbitmq.info docs pages being created.

This change should configure codox, when executed, to generate links to the source code for each function on the docs site.

Please let me know if there is anything else you need to make this work.