### PR TITLE
Allow customizing client-properties

### DIFF
--- a/src/clojure/langohr/core.clj
+++ b/src/clojure/langohr/core.clj
@@ -324,20 +324,23 @@
   [settings]
   (let [{:keys [host port username password vhost
                 requested-heartbeat connection-timeout ssl ssl-context verify-hostname socket-factory sasl-config
-                requested-channel-max thread-factory exception-handler]
+                requested-channel-max thread-factory exception-handler
+                connection-name]
          :or {requested-heartbeat ConnectionFactory/DEFAULT_HEARTBEAT
               connection-timeout  ConnectionFactory/DEFAULT_CONNECTION_TIMEOUT
               requested-channel-max ConnectionFactory/DEFAULT_CHANNEL_MAX
               sasl-config (auth-mechanism->sasl-config settings)}} (normalize-settings settings)
-              cf   (ConnectionFactory.)
-              final-port (if (and ssl (= port ConnectionFactory/DEFAULT_AMQP_PORT))
-                           ConnectionFactory/DEFAULT_AMQP_OVER_SSL_PORT
-                           port)]
+        cf   (ConnectionFactory.)
+        final-port (if (and ssl (= port ConnectionFactory/DEFAULT_AMQP_PORT))
+                     ConnectionFactory/DEFAULT_AMQP_OVER_SSL_PORT
+                     port)
+        final-properties (cond-> client-properties
+                           connection-name (assoc "connection_name" connection-name))]
     (when (or ssl
               (= port ConnectionFactory/DEFAULT_AMQP_OVER_SSL_PORT))
       (.useSslProtocol cf))
     (doto cf
-      (.setClientProperties   client-properties)
+      (.setClientProperties   final-properties)
       (.setUsername           username)
       (.setPassword           password)
       (.setVirtualHost        vhost)

--- a/src/clojure/langohr/core.clj
+++ b/src/clojure/langohr/core.clj
@@ -309,7 +309,7 @@
                      "information"  "See http://clojurerabbitmq.info/"
                      "platform"     (platform-string)
                      "capabilities" (get (AMQConnection/defaultClientProperties) "capabilities")
-                     "copyright"    "Copyright (C) 2011-2018 Michael S. Klishin, Alex Petrov"
+                     "copyright"    "Copyright (C) 2011-2020 Michael S. Klishin, Alex Petrov"
                      "version"      "5.1.0-SNAPSHOT"})
 
 (defn- auth-mechanism->sasl-config
@@ -325,7 +325,7 @@
   (let [{:keys [host port username password vhost
                 requested-heartbeat connection-timeout ssl ssl-context verify-hostname socket-factory sasl-config
                 requested-channel-max thread-factory exception-handler
-                connection-name]
+                connection-name update-client-properties]
          :or {requested-heartbeat ConnectionFactory/DEFAULT_HEARTBEAT
               connection-timeout  ConnectionFactory/DEFAULT_CONNECTION_TIMEOUT
               requested-channel-max ConnectionFactory/DEFAULT_CHANNEL_MAX
@@ -335,7 +335,8 @@
                      ConnectionFactory/DEFAULT_AMQP_OVER_SSL_PORT
                      port)
         final-properties (cond-> client-properties
-                           connection-name (assoc "connection_name" connection-name))]
+                           connection-name (assoc "connection_name" connection-name)
+                           update-client-properties update-client-properties)]
     (when (or ssl
               (= port ConnectionFactory/DEFAULT_AMQP_OVER_SSL_PORT))
       (.useSslProtocol cf))

--- a/test/langohr/test/properties_test.clj
+++ b/test/langohr/test/properties_test.clj
@@ -1,0 +1,37 @@
+;; Copyright (c) 2011-2020 Michael S. Klishin, Alex Petrov, and the ClojureWerkz Team
+;;
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file epl-v10.html at the root of this distribution.
+;; By using this software in any fashion, you are agreeing to be bound by
+;; the terms of this license.
+;; You must not remove this notice, or any other, from this software.
+
+(ns langohr.test.properties-test
+  "Connection recovery tests"
+  (:refer-clojure :exclude [await])
+  (:require [langohr.core     :as rmq]
+            [langohr.http    :as mgmt]
+            [clojure.test :refer :all]))
+
+;;
+;; Helpers
+;;
+
+(defn await-event-propagation
+  "Gives management plugin stats database a chance to update
+   (updates happen asynchronously)"
+  []
+  (Thread/sleep 1150))
+
+;;
+;; Tests
+;;
+
+(deftest test-connection-name
+  (with-open [conn (rmq/connect {:connection-name "George"})]
+    (is (rmq/open? conn))
+    (await-event-propagation)
+    (let [conns (mgmt/list-connections)]
+      (is (= 1 (count conns)))
+      (is (= "George" (-> conns first :user_provided_name))))))


### PR DESCRIPTION
As discussed, fixes #105 

`:connection-name` can now be used to name connections.

`:update-client-properties` allows clients to read and modify the default client-properties, this one i'm less sure about - the API is arguably a little bit odd, but it does provide the most flexibility.